### PR TITLE
Small fix for Mac binary install with v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_script:
 script:
   - asdf plugin-add awscli ./
   - asdf list-all awscli
-  - asdf plugin-test awscli ./ 'awscli version'
+  - asdf plugin-test awscli ./ 'aws version'
 os:
   - linux
   - osx

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ asdf install awscli latest 1 # 1.19.4
 asdf global awscli latest
 
 # Now awscli commands are available
-awscli --help
+aws --help
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -6,7 +6,7 @@ MAJOR_VERSION="${ASDF_INSTALL_VERSION:0:1}"
 OS_DISTRIBUTION="$(uname -s)"
 
 if [[ "${OS_DISTRIBUTION}" == "Darwin" && "${MAJOR_VERSION}" == "2" ]]; then
-  echo "aws-cli"
+  echo "bin"
 else
   echo "venv/bin"
 fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -64,7 +64,10 @@ install_version() {
       curl "${CURL_OPTS[@]}" -o "${release_file}" -C - "${url}" || fail "Could not download ${url}"
 
       pkgutil --expand-full "${release_file}" ./AWSCLIV2 || fail "Could not extract ${release_file}"
-      mv ./AWSCLIV2/aws-cli.pkg/Payload/aws-cli* "${install_path}/bin"
+      mv ./AWSCLIV2/aws-cli.pkg/Payload/aws-cli "${install_path}"
+      mkdir "${install_path}/bin"
+      ln -s "${install_path}/aws-cli/aws" "${install_path}/bin/aws"
+      ln -s "${install_path}/aws-cli/aws_completer" "${install_path}/bin/aws_completer"
       rm -rf "${release_file}" ./AWSCLIV2
 
       test -x "${test_path}" || fail "Expected ${test_path} to be executable."

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -48,7 +48,7 @@ install_version() {
   local install_path="$3"
   local os_distribution="$(uname -s)"
   local tool_cmd="$(echo "aws --help" | cut -d' ' -f1)"
-  local test_path="${install_path}/${tool_cmd}"
+  local test_path="${install_path}/bin/${tool_cmd}"
 
   if [ "${install_type}" != "version" ]; then
     fail "asdf-awscli supports release installs only"
@@ -64,8 +64,8 @@ install_version() {
       curl "${CURL_OPTS[@]}" -o "${release_file}" -C - "${url}" || fail "Could not download ${url}"
 
       pkgutil --expand-full "${release_file}" ./AWSCLIV2 || fail "Could not extract ${release_file}"
-      mv ./AWSCLIV2/aws-cli.pkg/Payload/aws-cli/* "${install_path}"
-      rm "${release_file}"
+      mv ./AWSCLIV2/aws-cli.pkg/Payload/aws-cli* "${install_path}/bin"
+      rm -rf "${release_file}" ./AWSCLIV2
 
       test -x "${test_path}" || fail "Expected ${test_path} to be executable."
     ) || (
@@ -90,7 +90,6 @@ install_version() {
 
       rm "${release_file}"
 
-      test_path="${install_path}/bin/${tool_cmd}"
       test -x "${test_path}" || fail "Expected ${test_path} to be executable."
     ) || (
       rm -rf "${install_path}"


### PR DESCRIPTION
Related to https://github.com/MetricMike/asdf-awscli/issues/2

During testing I found a couple issues:
* The bin-path was set to `aws-cli` but when moving the bins from the extracted `pkg` the binaries were all moved directly into the "awscli install path" (`~/.asdf/installs/awscli/` not `~/.asdf/installs/awscli/aws-cli`).
* Leaving the extracted package contents (`./AWSCLIV2`) in place causes future installs to fail.

Here's a before run:
```
❯ asdf plugin add awscli
❯ asdf install awscli latest
awscli 2.1.29 installation was successful!

# install claimed success but where is it? This is the bin-path mismatch.
❯ asdf which aws
unknown command: aws. Perhaps you have to reshim?

# let's try again
❯ asdf uninstall awscli 2.1.29
❯ asdf install awscli latest
Could not unarchive /Users/matt.klich/.asdf/installs/awscli/2.1.29/awscli-2.1.29.pkg (The operation couldn’t be completed. File exists)
asdf-awscli: Could not extract /Users/matt.klich/.asdf/installs/awscli/2.1.29/awscli-2.1.29.pkg
asdf-awscli: An error ocurred while installing awscli 2.1.29.
```

Here's with the PR fix:
```
❯ asdf plugin add awscli .
❯ asdf install awscli latest
awscli 2.1.29 installation was successful!

# found it!
❯ asdf which aws
/Users/matt.klich/.asdf/installs/awscli/2.1.29/bin/aws

# and a reinstall works now.
❯ asdf uninstall awscli 2.1.29
❯ asdf install awscli latest
awscli 2.1.29 installation was successful!
❯ asdf which aws
/Users/matt.klich/.asdf/installs/awscli/2.1.29/bin/aws
```