### PR TITLE
Install v2 using bundled release on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 
 # Dependencies
 
-- `bash`, `curl`, `tar`: generic POSIX utilities. These should be installed by default on most operating systems.
+- `bash`, `curl`, `tar`, `unzip`: generic POSIX utilities. These should be installed by default on most operating systems.
 
-- v1 - Linux/MacOS/Windows || v2 - Linux/Windows
+- v1 - Linux/MacOS/Windows || v2 - Windows
   - `Python 3.7.5+`: This plugin installs awscli from source into a virtualenv on these OS distributions. A currently maintained version of Python is required to do this.
 
 # Install

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -5,7 +5,7 @@ set -euo pipefail
 MAJOR_VERSION="${ASDF_INSTALL_VERSION:0:1}"
 OS_DISTRIBUTION="$(uname -s)"
 
-if [[ ( "${OS_DISTRIBUTION}" == "Darwin" || "${OS_DISTRIBUTION}" == "Linux" ) && "${MAJOR_VERSION}" == "2" ]]; then
+if [[ ("${OS_DISTRIBUTION}" == "Darwin" || "${OS_DISTRIBUTION}" == "Linux") && "${MAJOR_VERSION}" == "2" ]]; then
   echo "bin"
 else
   echo "venv/bin"

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -5,7 +5,7 @@ set -euo pipefail
 MAJOR_VERSION="${ASDF_INSTALL_VERSION:0:1}"
 OS_DISTRIBUTION="$(uname -s)"
 
-if [[ "${OS_DISTRIBUTION}" == "Darwin" && "${MAJOR_VERSION}" == "2" ]]; then
+if [[ ( "${OS_DISTRIBUTION}" == "Darwin" || "${OS_DISTRIBUTION}" == "Linux" ) && "${MAJOR_VERSION}" == "2" ]]; then
   echo "bin"
 else
   echo "venv/bin"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -75,6 +75,23 @@ install_version() {
       rm -rf "${install_path}"
       fail "An error ocurred while installing awscli ${version}."
     )
+  elif [[ "${os_distribution}" == "Linux" && "${major_version}" == "2" ]]; then
+    (
+      local release_file="${install_path}/awscli-${version}.zip"
+      local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${version}.zip"
+
+      curl "${CURL_OPTS[@]}" -o "${release_file}" -C - "${url}" || fail "Could not download ${url}"
+
+      unzip -q ${release_file} -d ./AWSCLIV2 || fail "Could not extract ${release_file}"
+      mkdir "${install_path}/bin"
+      ./AWSCLIV2/aws/install -i "${install_path}" -b "${install_path}/bin"
+      rm -rf "${release_file}" ./AWSCLIV2
+
+      test -x "${test_path}" || fail "Expected ${test_path} to be executable."
+    ) || (
+      rm -rf "${install_path}"
+      fail "An error ocurred while installing awscli ${version}."
+    )
   else
     local release_file="${install_path}/awscli-${version}.tar.gz"
     (


### PR DESCRIPTION
As discuss in #2, the modifications to use bundled releases for aws cli v2 on Linux