### PR TITLE
Add ARM64 system architecture support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -30,6 +30,7 @@ list_all_versions() {
   list_github_tags
 }
 
+
 download_release() {
   local version filename url
   version="$1"
@@ -47,11 +48,16 @@ install_version() {
   local major_version="${version:0:1}"
   local install_path="$3"
   local os_distribution="$(uname -s)"
+  local os_arch="$(uname -m)"
   local tool_cmd="$(echo "aws --help" | cut -d' ' -f1)"
   local test_path="${install_path}/bin/${tool_cmd}"
 
   if [ "${install_type}" != "version" ]; then
     fail "asdf-awscli supports release installs only"
+  fi
+
+  if [[ "$os_arch" != "x86_64" && "$os_arch" != "aarch64" ]]; then
+    fail "asdf-awscli only supports x86_64 and aarch64 system architectures"
   fi
 
   mkdir -p "${install_path}"
@@ -78,7 +84,7 @@ install_version() {
   elif [[ "${os_distribution}" == "Linux" && "${major_version}" == "2" ]]; then
     (
       local release_file="${install_path}/awscli-${version}.zip"
-      local url="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${version}.zip"
+      local url="https://awscli.amazonaws.com/awscli-exe-linux-${os_arch}-${version}.zip"
 
       curl "${CURL_OPTS[@]}" -o "${release_file}" -C - "${url}" || fail "Could not download ${url}"
 


### PR DESCRIPTION
The system architecture in the install script is hard-coded to x86_64 and awscli supports arm64 (aarch64). This change uses `uname -m` to get the system architecture from the host system before trying to install. awscli will throw an error if the wrong package is installed.
https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
```
$ aws --version
/lib64/ld-linux-x86-64.so.2: No such file or directory
``` 

## Description

In the lib/utils.bash file, I added a new variable `$os_arch` and set it to the output of `uname -m`
next I added a conditional that will throw an error if one of the two supported architectures are NOT stored in the os_arch variable
last I used that variable in the url to get the zip from aws.

## Motivation and Context

I use this package in a self-hosted github action runner that uses docker buildx to do multi-arch builds. I specifically build these containers to run on arm64 (raspberry pis) and the installation script (as is) does not install the correct package for this architecture. The existing script is already using `uname` to detect linux vs osx (darwin) and this change uses the same method to get the system architecture before installing.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

https://github.com/mathew-fleisch/blog/blob/main/blog/2021-05-17/self-hosted-github-action-runners-on-self-hosted-kubernetes-cluster.md

## How Has This Been Tested?

Via contributing guide, I ran this test locally.
```
$ asdf plugin test awscli https://github.com/mathew-fleisch/asdf-awscli.git "aws --version"
...
awscli 2.2.18 installation was successful!
aws-cli/2.2.18 Python/3.8.10 Linux/5.8.0-1026-raspi source/aarch64.ubuntu.20 prompt/off
```
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.