### PR TITLE
Allow using asdf-awscli on arm64 architectures (i.e. Apple Silicon)

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -55,8 +55,8 @@ install_version() {
     fail "asdf-awscli supports release installs only"
   fi
 
-  if [[ "$os_arch" != "x86_64" && "$os_arch" != "aarch64" ]]; then
-    fail "asdf-awscli only supports x86_64 and aarch64 system architectures"
+  if [[ "$os_arch" != "x86_64" && "$os_arch" != "aarch64" && "$os_arch" != "arm64" ]]; then
+    fail "asdf-awscli only supports x86_64, arm64, and aarch64 system architectures"
   fi
 
   mkdir -p "${install_path}"


### PR DESCRIPTION
Allows using this plugin on arm64 architectures like Apple Silicon. Tested out and it seems to work fine. I believe it's using Rosetta instead of a native binary, but the performance impact is negligible. Once AWS starts releasing a prebuilt arm64 binary (maybe universal? I don't know if that's even a thing anymore, but maybe?) I believe this script won't need to be updated.