### PR TITLE
fix: command on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Plugin:
 ```shell
 asdf plugin add awscli
 # or
-asdf plugin add https://github.com/MetricMike/asdf-awscli.git
+asdf plugin-add awscli https://github.com/MetricMike/asdf-awscli.git
 ```
 
 awscli:


### PR DESCRIPTION
docs:  When reading the documentation and trying to use the command : 

"asdf plugin add https://github.com/MetricMike/asdf-awscli.git" 

it returns an error as :

"https://github.com/MetricMike/asdf-awscli.git is invalid. Name may only contain lowercase letters, numbers, '_', and '-'" 

and reading the documentation the correct one would be : 

fix:  "asdf plugin-add awscli https://github.com/MetricMike/asdf-awscli.git"